### PR TITLE
Update to MP6 and JEE10

### DIFF
--- a/finish/client/pom.xml
+++ b/finish/client/pom.xml
@@ -8,8 +8,8 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>9.1.0</version>
+            <version>10.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/finish/client/src/main/liberty/config/server.xml
+++ b/finish/client/src/main/liberty/config/server.xml
@@ -2,8 +2,8 @@
 
     <featureManager>
         <!-- tag::features[] -->
-        <feature>restfulWS-3.0</feature>
-        <feature>websocket-2.0</feature>
+        <feature>restfulWS-3.1</feature>
+        <feature>websocket-2.1</feature>
         <feature>enterpriseBeansLite-4.0</feature>
         <!-- end::features[] -->
     </featureManager>

--- a/finish/client/src/main/webapp/index.html
+++ b/finish/client/src/main/webapp/index.html
@@ -1,6 +1,6 @@
 <!-- tag::copyright[] -->
 <!--
-  Copyright (c) 2022 IBM Corp.
+  Copyright (c) 2022, 2023 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@
                 <a href="https://openliberty.io/">openliberty.io</a>
             </div>
             <p id="footer_text">an IBM open source project</p>
-            <p id="footer_copyright">&copy;Copyright IBM Corp. 2022</p>
+            <p id="footer_copyright">&copy;Copyright IBM Corp. 2022, 2023</p>
         </footer>
         <script>
     const webSocket = new WebSocket('ws://localhost:9081/systemLoad')

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -48,6 +48,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>6.2.3.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
             <version>2.0.7</version>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -10,8 +10,8 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.1.0</version>
+            <version>10.0.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-client</artifactId>
-            <version>11.0.11</version>
+            <version>11.0.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -78,14 +78,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0</version>
             </plugin>
 
             <!-- Plugin to run integration tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0</version>
             </plugin>
         </plugins>
     </build>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -2,10 +2,10 @@
 
     <featureManager>
         <!-- tag::webSocket[] -->
-        <feature>websocket-2.0</feature>
+        <feature>websocket-2.1</feature>
         <!-- end::webSocket[] -->
         <!-- tag::jsonB[] -->
-        <feature>jsonb-2.0</feature>
+        <feature>jsonb-3.0</feature>
         <!-- end::jsonB[] -->
     </featureManager>
 

--- a/start/client/pom.xml
+++ b/start/client/pom.xml
@@ -8,8 +8,8 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>9.1.0</version>
+            <version>10.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/start/client/src/main/liberty/config/server.xml
+++ b/start/client/src/main/liberty/config/server.xml
@@ -2,8 +2,8 @@
 
     <featureManager>
         <!-- tag::features[] -->
-        <feature>restfulWS-3.0</feature>
-        <feature>websocket-2.0</feature>
+        <feature>restfulWS-3.1</feature>
+        <feature>websocket-2.1</feature>
         <feature>enterpriseBeansLite-4.0</feature>
         <!-- end::features[] -->
     </featureManager>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -48,6 +48,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>6.2.3.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
             <version>2.0.7</version>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -10,8 +10,8 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.1.0</version>
+            <version>10.0.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-client</artifactId>
-            <version>11.0.11</version>
+            <version>11.0.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -78,14 +78,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0</version>
             </plugin>
 
             <!-- Plugin to run integration tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0</version>
             </plugin>
         </plugins>
     </build>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -2,10 +2,10 @@
 
     <featureManager>
         <!-- tag::webSocket[] -->
-        <feature>websocket-2.0</feature>
+        <feature>websocket-2.1</feature>
         <!-- end::webSocket[] -->
         <!-- tag::jsonB[] -->
-        <feature>jsonb-2.0</feature>
+        <feature>jsonb-3.0</feature>
         <!-- end::jsonB[] -->
     </featureManager>
 


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/891

### Review changes
- [x]  pom.xml
  - java 11
  - jakarta is 10, microfile-profile is 6.0, and dependencies
  - LMP 3.7.1
- [x] server.xml
  - features version
- [x] index.html
  - license and features version
- [x] java files
  - EPL 2.0
- [x] License file
   - EPL 2.0

### End-to-end test
- [x] update lgdev with `version-update-mp6` branch
- [x] do end-to-end test and review content carefully
  - clone the `version-update-mp6` branch
  - if index.html has changes, make sure the links work
